### PR TITLE
feat: Add trailing commas and arrow parentheses options

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   singleQuote: true,
   quoteProps: 'consistent',
+  trailingCommas: 'all',
+  arrowParens: 'avoid',
   parser: 'typescript',
   endOfLine: 'auto',
 };


### PR DESCRIPTION
## Overview

Adds 2 new prettier configurations:

- `trailingCommas` set to `all`, since `es5` doesn't put commas to parameters.
- `arrowParens` set to `avoid`, synced wth `eslint` configuration file.