### PR TITLE
fix: Include jsdoc plugin rules to eslint config

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:jsdoc/recommended',
     'google',
     'prettier',
   ],


### PR DESCRIPTION
## Overview

This pull request adds `jsdoc` plugin rules to `eslint` config, which I forgot to include in the previous releases.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.8--canary.5.00e32c2856af3b22a7a1b5edb43a2a0dae9b27c1.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-namchee@1.0.8--canary.5.00e32c2856af3b22a7a1b5edb43a2a0dae9b27c1.0
  # or 
  yarn add eslint-config-namchee@1.0.8--canary.5.00e32c2856af3b22a7a1b5edb43a2a0dae9b27c1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
