### PR TITLE
feat: add typescript reference type comment rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 12,
+    ecmaVersion: 21,
     sourceType: 'module',
   },
   plugins: [

--- a/index.js
+++ b/index.js
@@ -62,6 +62,15 @@ module.exports = {
     'require-atomic-updates': 'off', // prevent async false alarm
     '@typescript-eslint/no-var-requires': 'off', // commonjs issue
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/camelcase': 'off' // prevent camelCase false alarm
+    '@typescript-eslint/camelcase': 'off', // prevent camelCase false alarm
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        markers: [
+          '/',
+        ],
+      },
+    ],
   },
 };


### PR DESCRIPTION
## Overview

This pull request adds `spaced-comment` rule that prevents [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) to be classified as an error.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.11--canary.7.4004bcf90e5ac04846adfdbba1fa582819f62ae5.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-namchee@1.0.11--canary.7.4004bcf90e5ac04846adfdbba1fa582819f62ae5.0
  # or 
  yarn add eslint-config-namchee@1.0.11--canary.7.4004bcf90e5ac04846adfdbba1fa582819f62ae5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
