### PR TITLE
fix: move XO config to peer dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,17 +21,13 @@ module.exports = {
     ecmaVersion: 21,
     sourceType: 'module',
   },
-  plugins: [
-    '@typescript-eslint',
-    'jsdoc',
-    'prettier',
-  ],
+  plugins: ['@typescript-eslint', 'jsdoc', 'prettier'],
   rules: {
     'indent': [
       'error',
       2,
       {
-        'SwitchCase': 1,
+        SwitchCase: 1,
       },
     ],
     'max-len': [
@@ -47,30 +43,23 @@ module.exports = {
     'new-cap': 'off',
     'no-tabs': 'error',
     'no-trailing-spaces': 'error',
-    'object-curly-spacing': [
-      'error',
-      'always',
-    ],
+    'object-curly-spacing': ['error', 'always'],
     'arrow-parens': [
       'error',
       'as-needed',
       {
-        'requireForBlockBody': true,
+        requireForBlockBody: true,
       },
     ],
     'require-jsdoc': 'off', // favor eslint-plugin-jsdoc
     'valid-jsdoc': 'off', // favor eslint-plugin-jsdoc
-    'no-invalid-this': 'off', // prevent `this` false alarm on arrow functions
-    'require-atomic-updates': 'off', // prevent async false alarm
     '@typescript-eslint/no-var-requires': 'off', // commonjs issue
-    '@typescript-eslint/camelcase': 'off', // prevent camelCase false alarm
+    '@typescript-eslint/camelcase': 'off',
     'spaced-comment': [
       'error',
       'always',
       {
-        markers: [
-          '/',
-        ],
+        markers: ['/'],
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "eslint": "^8.15.0",
+    "eslint-config-xo": "^0.41.0",
     "eslint-plugin-jsdoc": "^39.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.6.2",
@@ -33,7 +34,6 @@
   "devDependencies": {
     "@types/node": "^17.0.35",
     "auto": "^10.36.5",
-    "eslint-config-xo": "^0.41.0",
     "typescript": "^4.6.4"
   }
 }


### PR DESCRIPTION
## Overview

This pull request moves `eslint-config-xo` as peer dependencies instead of development dependencies.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.13--canary.9.2362691986.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-namchee@1.0.13--canary.9.2362691986.0
  # or 
  yarn add eslint-config-namchee@1.0.13--canary.9.2362691986.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
