### PR TITLE
fix: turn off no-unused-vars rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = {
         requireForBlockBody: true,
       },
     ],
+    'no-unused-vars': 'off', // prevent conflict with type declaration
     'require-jsdoc': 'off', // favor eslint-plugin-jsdoc
     'valid-jsdoc': 'off', // favor eslint-plugin-jsdoc
     '@typescript-eslint/no-var-requires': 'off', // commonjs issue

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.25.0",
-    "@typescript-eslint/parser": "^5.25.0",
+    "@typescript-eslint/eslint-plugin": "^5.37.0",
+    "@typescript-eslint/parser": "^5.37.0",
     "eslint": "^8.15.0",
     "eslint-config-xo": "^0.41.0",
     "eslint-plugin-jsdoc": "^39.3.0",


### PR DESCRIPTION
## Overview

This pull request turns off the `no-unused-vars` rule from the original ESLint config to prevent conflict with `@typescript-eslint/no-unused-vars` rule.

The original rule may conflict with some TypeScript features, for example:

```ts
// this will result a lint error.
type CallbackFn = (val: string) => string[];
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.14--canary.10.3076289686.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-namchee@1.0.14--canary.10.3076289686.0
  # or 
  yarn add eslint-config-namchee@1.0.14--canary.10.3076289686.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
