### PR TITLE
feat(eslint): enforce single quote style

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,5 +61,6 @@ module.exports = {
         markers: ['/'],
       },
     ],
+    'quotes': ['error', 'single'],
   },
 };

--- a/index.js
+++ b/index.js
@@ -61,6 +61,6 @@ module.exports = {
         markers: ['/'],
       },
     ],
-    'quotes': ['error', 'single'],
+    'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
   },
 };


### PR DESCRIPTION
## Overview

This pull request adds `quotes` rule that enforces single-quote string delimiters while allows back ticks to play around escaping sequences.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.16--canary.12.5532857485.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-namchee@1.0.16--canary.12.5532857485.0
  # or 
  yarn add eslint-config-namchee@1.0.16--canary.12.5532857485.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
