### PR TITLE
fix(deps): remove jsdoc integration from shared eslint config

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
     ecmaVersion: 21,
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint', 'jsdoc', 'prettier'],
+  plugins: ['@typescript-eslint', 'prettier'],
   rules: {
     'indent': [
       'error',


### PR DESCRIPTION
## Overview

This pull request removes `eslint-plugin-jsdoc` integrations from the shared ESLint configuration file since we dropped `jsdoc` from the previous version.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.17--canary.13.5982430605.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-namchee@1.0.17--canary.13.5982430605.0
  # or 
  yarn add eslint-config-namchee@1.0.17--canary.13.5982430605.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
