### PR TITLE
feat: august update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ module.exports = {
 }
 ```
 
+> Do note that this configuration is meant to be used with TypeScript in mind. Some features might not be compatible or available for vanilla JavaScript.
+
 ### Prettier
 
 To use the Prettier configuration, extend this configuration in your Prettier configuration file. Refer to the [official documentation](https://prettier.io/docs/en/index.html) for [how to extend Prettier configuration file](https://prettier.io/docs/en/configuration.html#sharing-configurations).

--- a/index.js
+++ b/index.js
@@ -51,8 +51,9 @@ module.exports = {
         requireForBlockBody: true,
       },
     ],
-    'no-unused-vars': 'off', // prevent conflict with type declaration
-    '@typescript-eslint/no-var-requires': 'off', // commonjs issue
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '_' }],
+    '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/camelcase': 'off',
     'spaced-comment': [
       'error',
@@ -61,6 +62,6 @@ module.exports = {
         markers: ['/'],
       },
     ],
-    'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
+    'quotes': ['error', 'single', { allowTemplateLiterals: true }],
   },
 };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'jsdoc', 'prettier'],
   rules: {
-    'indent': [
+    'indent': 'off',
+    '@typescript-eslint/indent': [
       'error',
       2,
       {


### PR DESCRIPTION
## Overview

This pull request introduces the following changes:

1. Add `_` as `no-unused-vars` escape sequence.
2. Replace `indent` with `@typescript-eslint/indent` to avoid `loc` bugs.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.18--canary.14.5982518908.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-namchee@1.0.18--canary.14.5982518908.0
  # or 
  yarn add eslint-config-namchee@1.0.18--canary.14.5982518908.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
