### PR TITLE
chore(deps): bump to v2 to avoid issues with legacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namchee/eslint-config",
-  "version": "1.0.19",
+  "version": "2.0.0",
   "description": "My personal ESLint configuration. Fits for most JS / TS projects.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Overview

This pull request bumps the flat config version to `v2` to avoid issues with the upcoming `legacy` branch.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.1--canary.18.6602974886.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/eslint-config@2.0.1--canary.18.6602974886.0
  # or 
  yarn add @namchee/eslint-config@2.0.1--canary.18.6602974886.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
