### PR TITLE
fix(rules): temporarily disable import/no-unresolved

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -183,7 +183,6 @@ module.exports = {
     'import/no-cycle': 'error',
     'import/no-duplicates': 'error',
     'import/no-extraneous-dependencies': 'error',
-    'import/no-unresolved': 'error',
 
     // unicorn plugin
     'unicorn/better-regex': 'error',


### PR DESCRIPTION
## Overview

This pull request temporarily disables `import/no-unresolved` due to https://github.com/import-js/eslint-plugin-import/issues/1868
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.5--canary.22.7102368876.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/eslint-config@2.0.5--canary.22.7102368876.0
  # or 
  yarn add @namchee/eslint-config@2.0.5--canary.22.7102368876.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
