### PR TITLE
chore: add type-hinting when defining rules

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -3,8 +3,9 @@ const unicorn = require('eslint-plugin-unicorn');
 const stylistic = require('@stylistic/eslint-plugin');
 const node = require('eslint-plugin-n');
 
+/** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
-  langOptions: {
+  languageOptions: {
     ecmaVersion: 'latest',
     globals: {
       Bun: 'readonly',

--- a/configs/js.js
+++ b/configs/js.js
@@ -2,6 +2,7 @@ const { langOptions, plugins, rules } = require('./base');
 
 const { GLOB_IGNORES, JS_FILES } = require('./const/globs');
 
+/** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
   languageOptions: langOptions,
   files: [JS_FILES],

--- a/configs/js.js
+++ b/configs/js.js
@@ -1,10 +1,10 @@
-const { langOptions, plugins, rules } = require('./base');
+const { languageOptions, plugins, rules } = require('./base');
 
 const { GLOB_IGNORES, JS_FILES } = require('./const/globs');
 
 /** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
-  languageOptions: langOptions,
+  languageOptions,
   files: [JS_FILES],
   ignores: GLOB_IGNORES,
   plugins: plugins,

--- a/configs/json.js
+++ b/configs/json.js
@@ -3,6 +3,7 @@ const parser = require('jsonc-eslint-parser');
 
 const { JSON_FILES } = require('./const/globs');
 
+/** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
   files: [JSON_FILES],
   ignores: ['**/package.json', '**/package-lock.json'],

--- a/configs/markdown.js
+++ b/configs/markdown.js
@@ -2,6 +2,7 @@ const markdown = require('eslint-plugin-markdown');
 
 const { MARKDOWN_FILES } = require('./const/globs');
 
+/** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
   files: [MARKDOWN_FILES],
   plugins: {

--- a/configs/ts.js
+++ b/configs/ts.js
@@ -10,7 +10,7 @@ const node = require('eslint-plugin-n');
 const canonical = require('eslint-plugin-canonical');
 
 const { TS_FILES, GLOB_IGNORES } = require('./const/globs');
-const { langOptions, plugins, rules } = require('./base');
+const { languageOptions, plugins, rules } = require('./base');
 
 const configPath = path.resolve(process.cwd(), 'tsconfig.json');
 const isConfigDefined = fs.existsSync(configPath);
@@ -26,7 +26,7 @@ module.exports = {
   files: [TS_FILES],
   ignores: GLOB_IGNORES,
   languageOptions: {
-    ...langOptions,
+    ...languageOptions,
     parser: parser,
     parserOptions: {
       ecmaVersion: 'latest',

--- a/configs/ts.js
+++ b/configs/ts.js
@@ -21,6 +21,7 @@ const unusedExports = isConfigDefined
   ? ['error', { tsConfigPath: configPath }]
   : 'off';
 
+/** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
   files: [TS_FILES],
   ignores: GLOB_IGNORES,

--- a/configs/yaml.js
+++ b/configs/yaml.js
@@ -3,6 +3,7 @@ const parser = require('yaml-eslint-parser');
 
 const { YAML_FILES } = require('./const/globs');
 
+/** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
   files: [YAML_FILES],
   ignores: ['**/pnpm-lock.yaml'],

--- a/index.js
+++ b/index.js
@@ -3,4 +3,5 @@ const ts = require('./configs/ts');
 const yaml = require('./configs/yaml');
 const json = require('./configs/json');
 
+/** @type {import('eslint').Linter.FlatConfig[]} */
 module.exports = [js, ts, yaml, json];


### PR DESCRIPTION
## Overview

This pull request adds rule type-hinting by `@types/eslint`. Hopefully, this will enhance DX when adding new ruleset.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.6--canary.23.7110315014.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/eslint-config@2.0.6--canary.23.7110315014.0
  # or 
  yarn add @namchee/eslint-config@2.0.6--canary.23.7110315014.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
