### PR TITLE
fix(canonical): disable no-unused-export

### DIFF
--- a/configs/ts.js
+++ b/configs/ts.js
@@ -17,9 +17,6 @@ const isConfigDefined = fs.existsSync(configPath);
 const recommendedRules = isConfigDefined
   ? ts.configs['recommended-type-checked'].rules
   : ts.configs.recommended.rules;
-const unusedExports = isConfigDefined
-  ? ['error', { tsConfigPath: configPath }]
-  : 'off';
 
 /** @type {import('eslint').Linter.FlatConfig} */
 module.exports = {
@@ -57,7 +54,6 @@ module.exports = {
 
     // canonical plugin, because this only works in TypeScript
     'canonical/no-barrel-import': 'error',
-    'canonical/no-unused-exports': unusedExports,
     'canonical/no-use-extend-native': 'error',
 
     // node rules


### PR DESCRIPTION
## Overview

This pull request disables `canonical/no-unused-exports` rule from typescript ruleset. This is due to its inability to detect imports from non-TS files (e.g: imported at Vue, React, or Astro files)