### PR TITLE
feat: add node globals to base script

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -11,9 +11,7 @@ module.exports = {
     ecmaVersion: 'latest',
     globals: {
       ...globals.browser,
-      Bun: 'readonly',
-      module: 'readonly',
-      require: 'readonly',
+      ...globals.node,
     },
   },
   plugins: {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-unicorn": "^48.0.1",
     "eslint-plugin-yaml": "^0.5.0",
+    "globals": "^13.24.0",
     "jsonc-eslint-parser": "^2.3.0",
     "yaml-eslint-parser": "^1.2.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   eslint-plugin-yaml:
     specifier: ^0.5.0
     version: 0.5.0
+  globals:
+    specifier: ^13.24.0
+    version: 13.24.0
   jsonc-eslint-parser:
     specifier: ^2.3.0
     version: 2.3.0
@@ -280,7 +283,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.6.1
-      globals: 13.20.0
+      globals: 13.24.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -1767,7 +1770,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.20.0
+      globals: 13.24.0
       graphemer: 1.4.0
       ignore: 5.2.4
       imurmurhash: 0.1.4
@@ -2077,8 +2080,8 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  /globals@13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+  /globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2


### PR DESCRIPTION
## Overview

This pull request adds all NodeJS globals to the base global config.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.9--canary.26.7375949708.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/eslint-config@2.0.9--canary.26.7375949708.0
  # or 
  yarn add @namchee/eslint-config@2.0.9--canary.26.7375949708.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
