### PR TITLE
feat: enable method-signature-style rule

### DIFF
--- a/configs/ts.js
+++ b/configs/ts.js
@@ -52,6 +52,12 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/prefer-ts-expect-error': 'error',
 
+    // https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful
+    '@typescript-eslint/method-signature-style': [
+      'error',
+      'property',
+    ],
+
     // canonical plugin, because this only works in TypeScript
     'canonical/no-barrel-import': 'error',
     'canonical/no-use-extend-native': 'error',


### PR DESCRIPTION
## Overview

This pull request enabled `method-signature-style` rule to prevent method shorthand syntax when defining methods on an interface or type. [Reasons are written here](https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.10--canary.27.7796330182.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/eslint-config@2.0.10--canary.27.7796330182.0
  # or 
  yarn add @namchee/eslint-config@2.0.10--canary.27.7796330182.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
