### PR TITLE
feat: introduce type-aware rules

### DIFF
--- a/.changeset/two-bobcats-dream.md
+++ b/.changeset/two-bobcats-dream.md
@@ -1,0 +1,5 @@
+---
+"@namchee/eslint-config": minor
+---
+
+feat: introduce type-aware rules

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The factory function accepts an optional parameter in form of key-value objects,
 | `toml` | Enables TOML rules. | `false` |
 | `unocss` | Enables UnoCSS-specific rules. | `false` |
 | `package` | Enables `package.json` rules. | `true` |
+| `typecheck` | Enables type-aware rules for TypeScript files. Do note for possible performance hit. | `false` |
 
 ## VSCode Settings
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The factory function accepts an optional parameter in form of key-value objects,
 | `toml` | Enables TOML rules. | `false` |
 | `unocss` | Enables UnoCSS-specific rules. | `false` |
 | `package` | Enables `package.json` rules. | `true` |
-| `typecheck` | Enables type-aware rules for TypeScript files. Do note for possible performance hit. | `false` |
+| `typecheck` | Enables type-aware rules for TypeScript files. Do note for possible performance hit. | `true` |
 
 ## VSCode Settings
 

--- a/configs/astro.ts
+++ b/configs/astro.ts
@@ -12,7 +12,7 @@ import globals from 'globals';
 
 import { BASE_CONFIG, STYLISTIC_CONFIG } from './base';
 import { ASTRO_FILES, ASTRO_SCRIPTS_TS_FILES } from './const/globs';
-import { TYPESCRIPT_RULES } from './typescript';
+import { STYLISTIC_TYPESCRIPT_RULES, TYPESCRIPT_RULES } from './typescript';
 
 export default function (config: Partial<Options> = {}): Linter.Config[] {
   return [
@@ -82,7 +82,7 @@ export default function (config: Partial<Options> = {}): Linter.Config[] {
       },
       rules: {
         ...TYPESCRIPT_RULES,
-        ...(config.stylistic ? { ...STYLISTIC_CONFIG.rules } : {}),
+        ...(config.stylistic ? { ...STYLISTIC_CONFIG.rules, ...STYLISTIC_TYPESCRIPT_RULES } : {}),
       },
     },
   ];

--- a/configs/typescript.ts
+++ b/configs/typescript.ts
@@ -66,6 +66,23 @@ export const TYPESCRIPT_RULES: Linter.RulesRecord = {
   'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
 };
 
+export const STYLISTIC_TYPESCRIPT_RULES: Linter.RulesRecord = {
+  'typescript/adjacent-overload-signatures': 'error',
+  'typescript/array-type': 'error',
+  'typescript/ban-tslint-comment': 'error',
+  'typescript/class-literal-property-style': 'error',
+  'typescript/consistent-generic-constructors': 'error',
+  'typescript/consistent-indexed-object-style': 'error',
+  'typescript/consistent-type-assertions': 'error',
+  'typescript/consistent-type-definitions': 'error',
+  'typescript/no-confusing-non-null-assertion': 'error',
+  'no-empty-function': 'off',
+  'typescript/no-empty-function': 'error',
+  'typescript/no-inferrable-types': 'error',
+  'typescript/prefer-for-of': 'error',
+  'typescript/prefer-function-type': 'error',
+};
+
 export default function (config: Partial<Options>): Linter.Config[] {
   return [{
     name: 'namchee/eslint/typescript',
@@ -94,7 +111,7 @@ export default function (config: Partial<Options>): Linter.Config[] {
     },
     rules: {
       ...TYPESCRIPT_RULES,
-      ...(config.stylistic ? STYLISTIC_CONFIG.rules : {}),
+      ...(config.stylistic ? { ...STYLISTIC_CONFIG.rules, ...STYLISTIC_TYPESCRIPT_RULES } : {}),
     },
   },
   {

--- a/configs/typescript.ts
+++ b/configs/typescript.ts
@@ -83,6 +83,32 @@ export const STYLISTIC_TYPESCRIPT_RULES: Linter.RulesRecord = {
   'typescript/prefer-function-type': 'error',
 };
 
+const TYPE_AWARE_RULES: Linter.RulesRecord = {
+  'dot-notation': 'off',
+  'typescript/dot-notation': ['error', { allowKeywords: true }],
+  'no-implied-eval': 'off',
+  'typescript/no-implied-eval': 'error',
+  'typescript/return-await': ['error', 'in-try-catch'],
+  'typescript/no-misused-promises': 'error',
+  'typescript/no-base-to-string': 'error',
+  'typescript/no-duplicate-enum-values': 'error',
+  'typescript/no-duplicate-type-constituents': 'error',
+  'typescript/no-empty-object-type': 'error',
+  'typescript/no-floating-promises': 'error',
+  'typescript/no-for-in-array': 'error',
+  'typescript/no-unsafe-argument': 'error',
+  'typescript/no-unsafe-assignment': 'error',
+  'typescript/no-unsafe-call': 'error',
+  'typescript/no-unsafe-member-access': 'error',
+  'typescript/no-unsafe-return': 'error',
+  'typescript/promise-function-async': 'error',
+  'typescript/only-throw-error': 'error',
+  'typescript/restrict-plus-operands': 'error',
+  'typescript/restrict-template-expressions': 'error',
+  'typescript/unbound-method': 'error',
+  'typescript/switch-exhaustiveness-check': 'error',
+};
+
 export default function (config: Partial<Options>): Linter.Config[] {
   return [{
     name: 'namchee/eslint/typescript',
@@ -111,6 +137,7 @@ export default function (config: Partial<Options>): Linter.Config[] {
     },
     rules: {
       ...TYPESCRIPT_RULES,
+      ...(config.typecheck ? TYPE_AWARE_RULES : {}),
       ...(config.stylistic ? { ...STYLISTIC_CONFIG.rules, ...STYLISTIC_TYPESCRIPT_RULES } : {}),
     },
   },

--- a/configs/vue.ts
+++ b/configs/vue.ts
@@ -10,7 +10,7 @@ import vueParser from 'vue-eslint-parser';
 
 import { BASE_CONFIG, STYLISTIC_CONFIG } from './base';
 import { VUE_FILES } from './const/globs';
-import { TYPESCRIPT_RULES } from './typescript';
+import { STYLISTIC_TYPESCRIPT_RULES, TYPESCRIPT_RULES } from './typescript';
 
 export default function (config: Partial<Options>): Linter.Config[] {
   return [{
@@ -80,7 +80,7 @@ export default function (config: Partial<Options>): Linter.Config[] {
       'vue/space-in-parens': ['error', 'never'],
       'vue/template-curly-spacing': 'error',
 
-      ...(config.stylistic ? STYLISTIC_CONFIG.rules : {}),
+      ...(config.stylistic ? { ...STYLISTIC_CONFIG.rules, ...STYLISTIC_TYPESCRIPT_RULES } : {}),
     },
   }];
 }

--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,7 @@ export function createESLintConfig(
     toml: false,
     unocss: false,
     package: true,
+    typecheck: false,
     ...userConfig,
   };
 

--- a/index.ts
+++ b/index.ts
@@ -61,6 +61,10 @@ export function createESLintConfig(
   const linters: Linter.Config[] = [...ignores(config), ...javascript(config)];
 
   for (const [key, value] of Object.entries(config)) {
+    if (key === 'typecheck') {
+      continue;
+    }
+
     if (value && CONFIG_MAP[key]) {
       linters.push(...CONFIG_MAP[key](config));
     }

--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,7 @@ export function createESLintConfig(
     toml: false,
     unocss: false,
     package: true,
-    typecheck: false,
+    typecheck: true,
     ...userConfig,
   };
 

--- a/options.ts
+++ b/options.ts
@@ -69,4 +69,11 @@ export interface Options {
    * Defaults to `true`
    */
   package: boolean;
+
+  /**
+   * Enable type-aware rules for TypeScript files.
+   *
+   * Defaults to `false` due to performance hit.
+   */
+  typecheck: boolean;
 }


### PR DESCRIPTION
## Overview

This pull request introduces toggleable type-aware rules from `@typescript-eslint`.

Due to possible performance hit, this feature is toggleable, but the default is `true`.

Moreover, this pull request also enables stylistic rules for typescript that isn't available in `@stylistic-eslint` package.