### PR TITLE
chore: ensure dot-notation on prop

### DIFF
--- a/configs/astro.ts
+++ b/configs/astro.ts
@@ -75,6 +75,7 @@ export default function (config: Partial<Options> = {}): Linter.Config[] {
       plugins: {
         ...BASE_CONFIG.plugins,
         // broken typings
+        // eslint-disable-next-line typescript/no-unsafe-assignment
         typescript: tsPlugin as any,
         canonical: canonical,
         import: importPlugin,
@@ -83,6 +84,8 @@ export default function (config: Partial<Options> = {}): Linter.Config[] {
       rules: {
         ...TYPESCRIPT_RULES,
         ...(config.stylistic ? { ...STYLISTIC_CONFIG.rules, ...STYLISTIC_TYPESCRIPT_RULES } : {}),
+        // astro passes class with className
+        'unicorn/no-keyword-prefix': 'off',
       },
     },
   ];

--- a/configs/base.ts
+++ b/configs/base.ts
@@ -225,7 +225,7 @@ export const STYLISTIC_CONFIG: Linter.Config = {
     'style/comma-spacing': 'error',
     'style/comma-style': 'error',
     'style/computed-property-spacing': 'error',
-    'style/dot-location': 'error',
+    'style/dot-location': ['error', 'property'],
     'style/eol-last': 'error',
     'style/function-call-spacing': 'error',
     'style/function-paren-newline': ['error', 'consistent'],


### PR DESCRIPTION
## Overview

This pull request fixes 2 rules:

1. `dot-location` which changes from `object` to `property`, which is more natural in multi-line declarations.
2. Disables `unicorn/no-keyword-prefix` for `astro` as Astro uses `className` to pass classes (idiomatically).