### PR TITLE
chore: patch repository.url for package provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Namchee's opinionated ESLint configuration.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/git@github.com:Namchee/eslint-config-namchee.git"
+    "url": "https://github.com/Namchee/eslint-config-namchee"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Overview

This pull request change the `repository.url` with correct HTTPS URL as required by provenance.